### PR TITLE
Add ESLint and Jest setup

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import App from '../App';
+
+test('renders correctly', () => {
+  render(<App />);
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'react', 'react-native'],
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:react-native/all',
+    'plugin:@typescript-eslint/recommended'
+  ],
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    ecmaFeatures: { jsx: true }
+  },
+  env: {
+    node: true,
+    'react-native/react-native': true
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  }
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(jest-)?react-native|@react-native|@react-navigation/.*)'
+  ],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/native": "^7.1.10",
@@ -21,7 +23,17 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@testing-library/jest-native": "^5.4.2",
+    "@testing-library/react-native": "^12.3.0",
+    "@types/jest": "^29.5.5",
     "@types/react": "~19.0.10",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.34.0",
+    "eslint-plugin-react-native": "^4.0.0",
+    "jest": "^29.7.0",
+    "jest-expo": "^49.0.1",
     "typescript": "~5.8.3"
   },
   "private": true


### PR DESCRIPTION
## Summary
- add eslint config with TypeScript and React Native rules
- configure Jest for React Native testing and add example test
- expose `lint` and `test` npm scripts with dependencies

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acbd52a588333bf0684b417f0b8e6